### PR TITLE
configure deployment.

### DIFF
--- a/.kubernetes/kubernetes_deployments.yaml
+++ b/.kubernetes/kubernetes_deployments.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fakebook-posts-api
+  labels:
+    app: fakebook-posts
+    role: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fakebook-posts
+      role: api
+  strategy:
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: fakebook-posts
+        role: api
+    spec:
+      containers:
+      - name: api
+        image: fakebookposts:latest
+        ports:
+        - containerPort: 80
+        env:
+        - name: ConnectionStrings__Default
+          value: 'Host=fakebook-posts-db;Database=postgres;Username=postgres;Password=Pass@word'
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fakebook-posts-db
+  labels:
+    app: fakebook-posts
+    role: db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fakebook-posts
+      role: db
+  template:
+    metadata:
+      labels:
+        app: fakebook-posts
+        role: db
+    spec:
+      containers:
+      - name: db
+        image: fakebookposts-db:latest
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: db-volume
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+      volumes:
+      - name: db-volume
+        persistentVolumeClaim:
+          claimName: fakebook-posts

--- a/.kubernetes/kubernetes_persistentvolumeclaim.yaml
+++ b/.kubernetes/kubernetes_persistentvolumeclaim.yaml
@@ -1,0 +1,15 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: fakebook-posts
+  labels:
+    app: fakebook-posts
+    role: db
+spec:
+  storageClassName: default
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi

--- a/.kubernetes/kubernetes_services.yaml
+++ b/.kubernetes/kubernetes_services.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fakebook-posts-api
+  labels:
+    app: fakebook-posts
+    role: api
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: fakebook-posts
+    role: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fakebook-posts-db
+  labels:
+    app: fakebook-posts
+    role: db
+spec:
+  ports:
+  - port: 5432
+  selector:
+    app: fakebook-posts
+    role: db

--- a/Fakebook.Posts/.config/dotnet-tools.json
+++ b/Fakebook.Posts/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "5.0.1",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}

--- a/Fakebook.Posts/app.dockerfile
+++ b/Fakebook.Posts/app.dockerfile
@@ -4,21 +4,18 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
 
 WORKDIR /app/src
 
-# -------------------------------- 
-# if the csproj file hasn't changed, we can cache up to this point
+# --------------------------------
 COPY Fakebook.Posts.Domain/*.csproj Fakebook.Posts.Domain/
 COPY Fakebook.Posts.DataAccess/*.csproj Fakebook.Posts.DataAccess/
 COPY Fakebook.Posts.RestApi/*.csproj Fakebook.Posts.RestApi/
 COPY Fakebook.Posts.UnitTests/*.csproj Fakebook.Posts.UnitTests/
 COPY *.sln ./
 RUN dotnet restore
-# --------------------------------- 
+# ---------------------------------
 
 COPY . ./
 
-RUN dotnet publish -o ../publish
-
-
+RUN dotnet publish Fakebook.Posts.RestApi -c Release -o ../publish
 
 #################- Package Assemblies -###################
 

--- a/Fakebook.Posts/db.dockerfile
+++ b/Fakebook.Posts/db.dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
+
+WORKDIR /app/src
+
+# --------------------------------
+COPY Fakebook.Posts.Domain/*.csproj Fakebook.Posts.Domain/
+COPY Fakebook.Posts.DataAccess/*.csproj Fakebook.Posts.DataAccess/
+COPY Fakebook.Posts.RestApi/*.csproj Fakebook.Posts.RestApi/
+COPY Fakebook.Posts.UnitTests/*.csproj Fakebook.Posts.UnitTests/
+COPY *.sln ./
+RUN dotnet restore
+# ---------------------------------
+COPY .config ./
+RUN dotnet tool restore
+# ---------------------------------
+
+COPY . ./
+
+# generate SQL script from migrations
+RUN dotnet ef migrations script -p Fakebook.Posts.DataAccess -s Fakebook.Posts.RestApi -o ../init-db.sql -i
+
+FROM postgres:13.0 AS runtime
+
+WORKDIR /docker-entrypoint-initdb.d
+
+ENV POSTGRES_PASSWORD Pass@word
+
+COPY --from=build /app/init-db.sql .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,6 +108,7 @@ stages:
         Dockerfile: '$(targetSolution)/app.dockerfile'
     - task: Docker@2
       displayName: docker build db image
+      continueOnError: true # until it has an actual DB
       inputs:
         repository: '$(imageName)-db'
         command: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,15 +94,78 @@ stages:
         pollingTimeoutSec: '300'
 
 - stage: docker
-  dependsOn: []
   variables:
     imageName: fakebookposts
   jobs:
   - job: build
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
     steps:
     - task: Docker@2
-      displayName: docker build image
+      displayName: docker build app image
       inputs:
         repository: '$(imageName)'
         command: 'build'
-        Dockerfile: '$(targetSolution)/Dockerfile'
+        Dockerfile: '$(targetSolution)/app.dockerfile'
+    - task: Docker@2
+      displayName: docker build db image
+      inputs:
+        repository: '$(imageName)-db'
+        command: 'build'
+        Dockerfile: '$(targetSolution)/db.dockerfile'
+  - job: build_push
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+    steps:
+    - publish: .kubernetes
+      displayName: publish artifact k8s
+      artifact: k8s
+    - task: Docker@2
+      displayName: docker build-push app image
+      inputs:
+        containerRegistry: 'fakebook-acr'
+        repository: '$(imageName)'
+        command: 'buildAndPush'
+        Dockerfile: '$(targetSolution)/app.dockerfile'
+        tags: |
+          latest
+          $(Build.BuildNumber)
+    - task: Docker@2
+      displayName: docker build-push db image
+      continueOnError: true # until it has an actual DB
+      inputs:
+        containerRegistry: 'fakebook-acr'
+        repository: '$(imageName)-db'
+        command: 'buildAndPush'
+        Dockerfile: '$(targetSolution)/db.dockerfile'
+        tags: |
+          latest
+          $(Build.BuildNumber)
+
+- stage: deploy
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  jobs:
+  - deployment: production
+    environment: production
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - task: KubernetesManifest@0
+            displayName: kubectl apply
+            inputs:
+              action: 'deploy'
+              kubernetesServiceConnection: 'production-fakebook-default-1610381990554'
+              namespace: 'default'
+              manifests: '$(Pipeline.Workspace)/k8s/**/*'
+
+          - task: Kubernetes@1
+            displayName: kubectl rollout restart
+            inputs:
+              connectionType: 'Kubernetes Service Connection'
+              kubernetesServiceEndpoint: 'production-fakebook-default-1610381990554'
+              namespace: 'default'
+              command: 'rollout'
+              useConfigurationFile: true
+              configuration: '$(Pipeline.Workspace)/k8s/kubernetes_deployments.yaml'
+              arguments: 'restart'
+              secretType: 'dockerRegistry'
+              containerRegistryType: 'Azure Container Registry'


### PR DESCRIPTION
cf. https://github.com/2011-fakebook-project3/notifications/pull/33, https://github.com/2011-fakebook-project3/profile/pull/20, and especially https://github.com/2011-fakebook-project3/ng/pull/37

routes /api/posts and /api/comments are currently sent to this api per the ng deployment PR.

there is a dockerfile for the database. it will look for migrations and generate a script to apply them. that script will run when the container starts. this includes any seed data configured using `HasData` in the context. this removes the need to do things like `Database.EnsureCreated()`. the context here is not configured in the Startup class yet, so that docker build fails, and is marked as allowed to fail in the pipeline; this should be changed when it is ready.