### PR TITLE
don't use port 5432 outside docker

### DIFF
--- a/Fakebook.Posts/Fakebook.Posts.RestApi/appsettings.Development.json
+++ b/Fakebook.Posts/Fakebook.Posts.RestApi/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionString": {
-    "default": "Host=localhost;Database=postgres;Username=postgres;Password=Pass@word"
+    "default": "Host=localhost;Port=5434;Database=postgres;Username=postgres;Password=Pass@word"
   },
   "Logging": {
     "LogLevel": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       dockerfile: db.dockerfile
     image: fakebookposts-db:latest
     ports:
-    - 5432:5432
+    - 5434:5432
     environment:
       POSTGRES_PASSWORD: Pass@word
     volumes:


### PR DESCRIPTION
some (but not all) devs hit an error with the posts database container, where EF would throw an exception saying login failed for user postgres. (the db logs would not indicate anything)

issue is present when container's postgres port is mapped to 5432 (the usual postgres default); issue not present when it's mapped to a different port. issue didn't occur for profile db, possibly because it was already on a different port as well to avoid collision on the host dev machine with posts db.

in the production cluster, we're still using 5432 for both this and profile's DBs, since the pods & services have their own networking abstractions to make this straightforward.