### PR TITLE
Added unit test for existing business post and comment models

### DIFF
--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
@@ -7,22 +7,27 @@ namespace Fakebook.Posts.Domain.Models
     public class Comment
     {
         public int Id { get; set; }
-        private string _Content; 
+        private string _Content;
         public Post Post { get; set; }
         private string _UserEmail;
         public DateTime CreatedAt { get; set; }
         public ICollection<string> Likes { get; set; }
-        
 
-        public string UserEmail{
-            get{
+
+        public string UserEmail
+        {
+            get
+            {
                 return _UserEmail;
             }
-            set{
-                if(value.Contains('@')){
+            set
+            {
+                if (value.Contains('@'))
+                {
                     _UserEmail = value;
                 }
-                else{
+                else
+                {
                     throw new ArgumentException("A correct email format is required.");
                 }
             }
@@ -30,16 +35,20 @@ namespace Fakebook.Posts.Domain.Models
         }
 
 
-        public string Content{
-            get{
+        public string Content
+        {
+            get
+            {
                 return _Content;
             }
-            set{
-                if(value.Length > 1)
+            set
+            {
+                if (value.Length > 1)
                 {
                     _Content = value;
                 }
-                else{
+                else
+                {
                     throw new ArgumentException("Please enter a comment.");
                 }
             }

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
@@ -7,16 +7,48 @@ namespace Fakebook.Posts.Domain.Models
     public class Comment
     {
         public int Id { get; set; }
-        public string Content { get; set; }
+        private string _Content; 
         public Post Post { get; set; }
-        public string UserEmail { get; private set; }
+        private string _UserEmail;
         public DateTime CreatedAt { get; set; }
         public ICollection<string> Likes { get; set; }
+        
+
+        public string UserEmail{
+            get{
+                return _UserEmail;
+            }
+            set{
+                if(value.Contains('@')){
+                    _UserEmail = value;
+                }
+                else{
+                    throw new ArgumentException("A correct email format is required.");
+                }
+            }
+
+        }
+
+
+        public string Content{
+            get{
+                return _Content;
+            }
+            set{
+                if(value.Length > 1)
+                {
+                    _Content = value;
+                }
+                else{
+                    throw new ArgumentException("Please enter a comment.");
+                }
+            }
+        }
+
+
 
         public Comment(string userEmail, string content)
         {
-            if (string.IsNullOrWhiteSpace(userEmail)) throw new ArgumentException("User email is required.", nameof(userEmail));
-            if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Post content is required.", nameof(content));
             UserEmail = userEmail;
             Content = content;
             Likes = new HashSet<string>();

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
@@ -21,7 +21,7 @@ namespace Fakebook.Posts.Domain.Models
         {
             if (string.IsNullOrWhiteSpace(userEmail)) throw new ArgumentException("User email is required.", nameof(userEmail));
             if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Post content is required.", nameof(content));
-            if (!userEmail.Contains("@")) throw new ArgumentException("Post content is required.", nameof(content));
+            if (!userEmail.Contains("@")) throw new ArgumentException("Post content is required.", nameof(userEmail));
 
             UserEmail = userEmail;
             Content = content;

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
@@ -21,7 +21,7 @@ namespace Fakebook.Posts.Domain.Models
         {
             if (string.IsNullOrWhiteSpace(userEmail)) throw new ArgumentException("User email is required.", nameof(userEmail));
             if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Post content is required.", nameof(content));
-            if (!userEmail.Contains("@")) throw new ArgumentException("Post content is required.", nameof(userEmail));
+            if (!userEmail.Contains("@")) throw new ArgumentException("Correct email format is required.", nameof(userEmail));
 
             UserEmail = userEmail;
             Content = content;

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
@@ -7,57 +7,22 @@ namespace Fakebook.Posts.Domain.Models
     public class Comment
     {
         public int Id { get; set; }
-        private string _Content;
+        public string Content { get; set; }
         public Post Post { get; set; }
-        private string _UserEmail;
+        public string UserEmail { get; private set; }
         public DateTime CreatedAt { get; set; }
         public ICollection<string> Likes { get; set; }
 
 
-        public string UserEmail
-        {
-            get
-            {
-                return _UserEmail;
-            }
-            set
-            {
-                if (value.Contains('@'))
-                {
-                    _UserEmail = value;
-                }
-                else
-                {
-                    throw new ArgumentException("A correct email format is required.");
-                }
-            }
-
-        }
-
-
-        public string Content
-        {
-            get
-            {
-                return _Content;
-            }
-            set
-            {
-                if (value.Length > 1)
-                {
-                    _Content = value;
-                }
-                else
-                {
-                    throw new ArgumentException("Please enter a comment.");
-                }
-            }
-        }
 
 
 
         public Comment(string userEmail, string content)
         {
+            if (string.IsNullOrWhiteSpace(userEmail)) throw new ArgumentException("User email is required.", nameof(userEmail));
+            if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Post content is required.", nameof(content));
+            if (!userEmail.Contains("@")) throw new ArgumentException("Post content is required.", nameof(content));
+
             UserEmail = userEmail;
             Content = content;
             Likes = new HashSet<string>();

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Post.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Post.cs
@@ -6,17 +6,47 @@ namespace Fakebook.Posts.Domain.Models
     public class Post
     {
         public int Id { get; set; }
-        public string Content { get; set; }
+        private string _Content; 
         public string Picture { get; set; }
-        public string UserEmail { get; private set; }
+         private string _UserEmail;
         public DateTime CreatedAt { get; set; }
         public ICollection<Comment> Comments { get; set; }
         public ICollection<string> Likes { get; set; }
 
+
+         public string UserEmail{
+            get{
+                return _UserEmail;
+            }
+            set{
+                if(value.Contains('@')){
+                    _UserEmail = value;
+                }
+                else{
+                    throw new ArgumentException("A correct email format is required.");
+                }
+            }
+
+        }
+
+
+        public string Content{
+            get{
+                return _Content;
+            }
+            set{
+                if(value.Length > 1)
+                {
+                    _Content = value;
+                }
+                else{
+                    throw new ArgumentException("Please enter a comment.");
+                }
+            }
+        }
+
         public Post(string userEmail, string content)
         {
-            if (string.IsNullOrWhiteSpace(userEmail)) throw new ArgumentException("User email is required.", nameof(userEmail));
-            if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Post content is required.", nameof(content));
             UserEmail = userEmail;
             Content = content;
             Comments = new HashSet<Comment>();

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Post.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Post.cs
@@ -17,7 +17,7 @@ namespace Fakebook.Posts.Domain.Models
         {
             if (string.IsNullOrWhiteSpace(userEmail)) throw new ArgumentException("User email is required.", nameof(userEmail));
             if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Post content is required.", nameof(content));
-            if (!userEmail.Contains("@")) throw new ArgumentException("Post content is required.", nameof(userEmail));
+            if (!userEmail.Contains("@")) throw new ArgumentException("Correct email format is required.", nameof(userEmail));
             
             UserEmail = userEmail;
             Content = content;

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Post.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Post.cs
@@ -18,6 +18,7 @@ namespace Fakebook.Posts.Domain.Models
             if (string.IsNullOrWhiteSpace(userEmail)) throw new ArgumentException("User email is required.", nameof(userEmail));
             if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Post content is required.", nameof(content));
             if (!userEmail.Contains("@")) throw new ArgumentException("Post content is required.", nameof(content));
+            
             UserEmail = userEmail;
             Content = content;
             Comments = new HashSet<Comment>();

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Post.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Post.cs
@@ -17,7 +17,7 @@ namespace Fakebook.Posts.Domain.Models
         {
             if (string.IsNullOrWhiteSpace(userEmail)) throw new ArgumentException("User email is required.", nameof(userEmail));
             if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Post content is required.", nameof(content));
-            if (!userEmail.Contains("@")) throw new ArgumentException("Post content is required.", nameof(content));
+            if (!userEmail.Contains("@")) throw new ArgumentException("Post content is required.", nameof(userEmail));
             
             UserEmail = userEmail;
             Content = content;

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Post.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Post.cs
@@ -6,47 +6,18 @@ namespace Fakebook.Posts.Domain.Models
     public class Post
     {
         public int Id { get; set; }
-        private string _Content; 
+        public string Content { get; set; }
         public string Picture { get; set; }
-         private string _UserEmail;
+        public string UserEmail { get; private set; }
         public DateTime CreatedAt { get; set; }
         public ICollection<Comment> Comments { get; set; }
         public ICollection<string> Likes { get; set; }
 
-
-         public string UserEmail{
-            get{
-                return _UserEmail;
-            }
-            set{
-                if(value.Contains('@')){
-                    _UserEmail = value;
-                }
-                else{
-                    throw new ArgumentException("A correct email format is required.");
-                }
-            }
-
-        }
-
-
-        public string Content{
-            get{
-                return _Content;
-            }
-            set{
-                if(value.Length > 1)
-                {
-                    _Content = value;
-                }
-                else{
-                    throw new ArgumentException("Please enter a comment.");
-                }
-            }
-        }
-
         public Post(string userEmail, string content)
         {
+            if (string.IsNullOrWhiteSpace(userEmail)) throw new ArgumentException("User email is required.", nameof(userEmail));
+            if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Post content is required.", nameof(content));
+            if (!userEmail.Contains("@")) throw new ArgumentException("Post content is required.", nameof(content));
             UserEmail = userEmail;
             Content = content;
             Comments = new HashSet<Comment>();

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/Controllers/DeletePostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/Controllers/DeletePostTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Fakebook.Posts.Domain.Interfaces;
 using Fakebook.Posts.Domain.Models;
@@ -10,34 +8,34 @@ using Fakebook.Posts.RestApi.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
-namespace Fakebook.Posts.UnitTests.Controllers
+namespace Fakebook.Posts.IntegrationTests.Controllers
 {
-    public class EditPostTests : IClassFixture<WebApplicationFactory<Startup>>
+    public class DeletePostTests : IClassFixture<WebApplicationFactory<Startup>>
     {
 
         private readonly WebApplicationFactory<Startup> _factory;
 
-        public EditPostTests(WebApplicationFactory<Startup> factory)
+        public DeletePostTests(WebApplicationFactory<Startup> factory)
         {
             _factory = factory;
         }
 
         /// <summary>
-        /// Tests the PostsController class' PutAsync method. Ensures that a proper Post object results in status 204NoContent.
+        /// Tests the PostsController class' DeleteAsync method. Ensures that a proper id results in status 204NoContent.
         /// </summary>
         [Fact]
-        public async Task PutAsync_ValidPost_Updates()
+        public async Task DeleteAsync_ValidId_Deletes()
         {
+
             // Arrange
             Mock<IPostsRepository> mockRepo = new();
             Mock<IFollowsRepository> mockFollowRepo = new();
             Mock<IBlobService> mockBlobService = new();
-            mockRepo.Setup(r => r.UpdateAsync(It.IsAny<Post>()))
+            mockRepo.Setup(r => r.DeletePostAsync(It.IsAny<int>()))
                 .Returns(new ValueTask());
 
             HashSet<Post> posts = new()
@@ -62,18 +60,8 @@ namespace Fakebook.Posts.UnitTests.Controllers
 
             client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Test");
 
-            Post post = new("test@email.com", "message")
-            {
-                Id = 1,
-                Comments = new HashSet<Comment>(),
-                Picture = "picture",
-                CreatedAt = DateTime.Now
-            };
-
-            StringContent stringContent = new(System.Text.Json.JsonSerializer.Serialize(post), Encoding.UTF8, "application/json");
-
             // Act
-            var response = await client.PutAsync("api/posts/1", stringContent);
+            var response = await client.DeleteAsync("api/posts/1");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -84,14 +72,14 @@ namespace Fakebook.Posts.UnitTests.Controllers
         /// Tests the PostsController class' PutAsync method. Ensures that an improper Post object results in status 400BadRequest with an error message in the body.
         /// </summary>
         [Fact]
-        public async Task PutAsync_InvalidPost_BadRequest()
+        public async Task DeleteAsync_InvalidId_NotFound()
         {
             // Arrange
             Mock<IPostsRepository> mockRepo = new();
             Mock<IFollowsRepository> mockFollowRepo = new();
             Mock<IBlobService> mockBlobService = new();
-            mockRepo.Setup(r => r.UpdateAsync(It.IsAny<Post>()))
-                .Throws(new DbUpdateException());
+            mockRepo.Setup(r => r.DeletePostAsync(It.IsAny<int>()))
+                .Throws(new ArgumentException());
 
             HashSet<Post> posts = new()
             {
@@ -115,21 +103,11 @@ namespace Fakebook.Posts.UnitTests.Controllers
 
             client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Test");
 
-            Post post = new("test@email.com", "message")
-            {
-                Id = 1,
-                Comments = new HashSet<Comment>(),
-                Picture = "picture",
-                CreatedAt = DateTime.Now
-            };
-
-            StringContent stringContent = new(System.Text.Json.JsonSerializer.Serialize(post), Encoding.UTF8, "application/json");
-
             // Act
-            var response = await client.PutAsync("api/posts/1", stringContent);
+            var response = await client.DeleteAsync("api/posts/1");
 
             // Assert
-            Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/Controllers/FollowsControllerTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/Controllers/FollowsControllerTests.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
-namespace Fakebook.Posts.UnitTests.Controllers
+namespace Fakebook.Posts.IntegrationTests.Controllers
 {
     public class FollowsControllerTests : IClassFixture<WebApplicationFactory<Startup>>
     {

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/Controllers/PostControllerTest.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/Controllers/PostControllerTest.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
-namespace Fakebook.Posts.UnitTests.Controllers
+namespace Fakebook.Posts.IntegrationTests.Controllers
 {
     public class PostControllerTest : IClassFixture<WebApplicationFactory<Startup>>
     {

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/Fakebook.Posts.IntegrationTests.csproj
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/Fakebook.Posts.IntegrationTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Fakebook.Posts.DataAccess\Fakebook.Posts.DataAccess.csproj" />
+    <ProjectReference Include="..\Fakebook.Posts.Domain\Fakebook.Posts.Domain.csproj" />
+    <ProjectReference Include="..\Fakebook.Posts.RestApi\Fakebook.Posts.RestApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/DeleteCommentTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/DeleteCommentTests.cs
@@ -6,16 +6,16 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
-namespace Fakebook.Posts.UnitTests.Repositories
+namespace Fakebook.Posts.IntegrationTests.Repositories
 {
-    public class DeletePostTests
+    public class DeleteCommentTests
     {
 
         /// <summary>
         /// Tests the PostsRepository class' UpdateAsync method. Ensures that a proper Post object results in the database being modified.
         /// </summary>
         [Fact]
-        public async Task DeletePostAsync_ValidId_Removes()
+        public async Task DeleteCommentAsync_ValidId_Removes()
         {
 
             // Arrange
@@ -34,19 +34,29 @@ namespace Fakebook.Posts.UnitTests.Repositories
                 CreatedAt = DateTime.Now
             };
 
+            DataAccess.Models.Comment insertedComment = new()
+            {
+                Id = 2,
+                PostId = 3,
+                UserEmail = "person@domain.net",
+                Content = "New Content",
+                CreatedAt = DateTime.Now
+            };
+
             using FakebookPostsContext context = new(options);
             context.Database.EnsureCreated();
             context.Posts.Add(insertedPost);
+            context.Comments.Add(insertedComment);
             context.SaveChanges();
 
             PostsRepository repo = new(context);
 
             //Act
-            await repo.DeletePostAsync(3);
+            await repo.DeleteCommentAsync(2);
             context.SaveChanges();
 
             // Assert
-            Assert.DoesNotContain(insertedPost, context.Posts);
+            Assert.DoesNotContain(insertedComment, context.Comments);
         }
     }
 }

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/DeletePostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/DeletePostTests.cs
@@ -6,16 +6,16 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
-namespace Fakebook.Posts.UnitTests.Repositories
+namespace Fakebook.Posts.IntegrationTests.Repositories
 {
-    public class DeleteCommentTests
+    public class DeletePostTests
     {
 
         /// <summary>
         /// Tests the PostsRepository class' UpdateAsync method. Ensures that a proper Post object results in the database being modified.
         /// </summary>
         [Fact]
-        public async Task DeleteCommentAsync_ValidId_Removes()
+        public async Task DeletePostAsync_ValidId_Removes()
         {
 
             // Arrange
@@ -34,29 +34,19 @@ namespace Fakebook.Posts.UnitTests.Repositories
                 CreatedAt = DateTime.Now
             };
 
-            DataAccess.Models.Comment insertedComment = new()
-            {
-                Id = 2,
-                PostId = 3,
-                UserEmail = "person@domain.net",
-                Content = "New Content",
-                CreatedAt = DateTime.Now
-            };
-
             using FakebookPostsContext context = new(options);
             context.Database.EnsureCreated();
             context.Posts.Add(insertedPost);
-            context.Comments.Add(insertedComment);
             context.SaveChanges();
 
             PostsRepository repo = new(context);
 
             //Act
-            await repo.DeleteCommentAsync(2);
+            await repo.DeletePostAsync(3);
             context.SaveChanges();
 
             // Assert
-            Assert.DoesNotContain(insertedComment, context.Comments);
+            Assert.DoesNotContain(insertedPost, context.Posts);
         }
     }
 }

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/EditPostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/EditPostTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
-namespace Fakebook.Posts.UnitTests.Repositories
+namespace Fakebook.Posts.IntegrationTests.Repositories
 {
     public class EditPostTests
     {

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/PostRepository_CreateTest.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/PostRepository_CreateTest.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 
-namespace Fakebook.Posts.UnitTests.PostRepository.Test
+namespace Fakebook.Posts.IntegrationTests.PostRepository.Test
 {
     public class PostRepository_CreateTest
     {

--- a/Fakebook.Posts/Fakebook.Posts.RestApi/Fakebook.Posts.RestApi.csproj
+++ b/Fakebook.Posts/Fakebook.Posts.RestApi/Fakebook.Posts.RestApi.csproj
@@ -6,6 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="NewFolder1\**" />
+    <Content Remove="NewFolder1\**" />
+    <EmbeddedResource Remove="NewFolder1\**" />
+    <None Remove="NewFolder1\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.4" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.4" NoWarn="NU1605" />

--- a/Fakebook.Posts/Fakebook.Posts.UnitTests/CommentTest.cs
+++ b/Fakebook.Posts/Fakebook.Posts.UnitTests/CommentTest.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Fakebook.Posts.Domain.Models;
+using Xunit;
+namespace Fakebook.Posts.UnitTests
+{
+
+    public class CommentTest{
+        private const int Id = 1;
+        [Fact]
+        public void Comment_Constructor_Pass(){
+            //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silver@test.com";
+            //act
+            Comment newcomment = new Comment(userEmail, Content);
+
+            //assert
+                Assert.NotNull(newcomment);
+        }
+
+
+           [Fact]
+        public void Comment_EmailIsNotNull(){
+            //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silver@test.com";
+            //act
+            Comment newcomment = new Comment(userEmail, Content);
+
+            //assert
+                Assert.NotNull(newcomment.UserEmail);
+        }
+
+
+        [Fact]
+        public void Comment_EmailEquality(){
+
+             //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silver@test.com";
+            //act
+            Comment newcomment = new Comment(userEmail, Content);
+
+            //assert
+                Assert.Equal(userEmail,newcomment.UserEmail);
+        }
+
+
+            [Fact]
+        public void Comment_ContentIsNotNull(){
+            //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silver@test.com";
+            //act
+            Comment newcomment = new Comment(userEmail, Content);
+
+            //assert
+                Assert.NotNull(newcomment.Content);
+        }
+
+            [Fact]
+        public void Comment_EmailisFormattedCorrectly(){
+            //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silver@test.com";
+            //act
+            Comment newcomment = new Comment(userEmail, Content);
+
+            //assert
+                Assert.Contains("@", newcomment.UserEmail);
+        }
+
+           public void Comment_EmailFormationThrowsException(){
+            //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silvertest.com";
+            //act
+           
+            
+
+            //assert
+                Assert.Throws<ArgumentException>(() => new Comment(userEmail, Content));
+
+        }
+
+    }
+}

--- a/Fakebook.Posts/Fakebook.Posts.UnitTests/CommentTest.cs
+++ b/Fakebook.Posts/Fakebook.Posts.UnitTests/CommentTest.cs
@@ -8,82 +8,89 @@ using Xunit;
 namespace Fakebook.Posts.UnitTests
 {
 
-    public class CommentTest{
+    public class CommentTest
+    {
         private const int Id = 1;
         [Fact]
-        public void Comment_Constructor_Pass(){
+        public void Comment_Constructor_Pass()
+        {
             //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silver@test.com";
+            const string Content = "This is some content";
+            const string userEmail = "damion.silver@test.com";
             //act
             Comment newcomment = new Comment(userEmail, Content);
 
             //assert
-                Assert.NotNull(newcomment);
-        }
-
-
-           [Fact]
-        public void Comment_EmailIsNotNull(){
-            //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silver@test.com";
-            //act
-            Comment newcomment = new Comment(userEmail, Content);
-
-            //assert
-                Assert.NotNull(newcomment.UserEmail);
+            Assert.NotNull(newcomment);
         }
 
 
         [Fact]
-        public void Comment_EmailEquality(){
-
-             //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silver@test.com";
+        public void Comment_EmailIsNotNull()
+        {
+            //arrange
+            const string Content = "This is some content";
+            const string userEmail = "damion.silver@test.com";
             //act
             Comment newcomment = new Comment(userEmail, Content);
 
             //assert
-                Assert.Equal(userEmail,newcomment.UserEmail);
+            Assert.NotNull(newcomment.UserEmail);
         }
 
 
-            [Fact]
-        public void Comment_ContentIsNotNull(){
+        [Fact]
+        public void Comment_EmailEquality()
+        {
+
             //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silver@test.com";
+            const string Content = "This is some content";
+            const string userEmail = "damion.silver@test.com";
             //act
             Comment newcomment = new Comment(userEmail, Content);
 
             //assert
-                Assert.NotNull(newcomment.Content);
+            Assert.Equal(userEmail, newcomment.UserEmail);
         }
 
-            [Fact]
-        public void Comment_EmailisFormattedCorrectly(){
+
+        [Fact]
+        public void Comment_ContentIsNotNull()
+        {
             //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silver@test.com";
+            const string Content = "This is some content";
+            const string userEmail = "damion.silver@test.com";
             //act
             Comment newcomment = new Comment(userEmail, Content);
 
             //assert
-                Assert.Contains("@", newcomment.UserEmail);
+            Assert.NotNull(newcomment.Content);
         }
 
-           public void Comment_EmailFormationThrowsException(){
+        [Fact]
+        public void Comment_EmailisFormattedCorrectly()
+        {
             //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silvertest.com";
+            const string Content = "This is some content";
+            const string userEmail = "damion.silver@test.com";
             //act
-           
-            
+            Comment newcomment = new Comment(userEmail, Content);
 
             //assert
-                Assert.Throws<ArgumentException>(() => new Comment(userEmail, Content));
+            Assert.Contains("@", newcomment.UserEmail);
+        }
+
+        public void Comment_EmailFormationThrowsException()
+        {
+            //arrange
+            const string Content = "This is some content";
+            const string userEmail = "damion.silvertest.com";
+            //act
+
+
+
+            //assert
+            Assert.Throws<ArgumentException>(() => new Comment(userEmail, Content));
 
         }
 

--- a/Fakebook.Posts/Fakebook.Posts.UnitTests/PostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.UnitTests/PostTests.cs
@@ -8,99 +8,86 @@ using Xunit;
 namespace Fakebook.Posts.UnitTests
 {
 
-    public class PostTests{
+    public class PostTests
+    {
         private const int Id = 1;
         [Fact]
-        public void Post_Constructor_Pass(){
+        public void Post_Constructor_Pass()
+        {
             //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silver@test.com";
+            const string Content = "This is some content";
+            const string userEmail = "damion.silver@test.com";
             //act
-            Post newpost = new Post(userEmail,Content);
+            Post newpost = new Post(userEmail, Content);
 
             //assert
-                Assert.NotNull(newpost);
-        }
-    
-
-         [Fact]
-        public void Post_EmailIsNotNull(){
-            //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silver@test.com";
-            //act
-            Post newcomment = new Post(userEmail, Content);
-
-            //assert
-                Assert.NotNull(newcomment.UserEmail);
+            Assert.NotNull(newpost);
         }
 
 
         [Fact]
-        public void Post_EmailEquality(){
-
-             //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silver@test.com";
-            //act
-            Post newcomment = new Post(userEmail, Content);
-
-            //assert
-                Assert.Equal(userEmail,newcomment.UserEmail);
-        }
-
-
-            [Fact]
-        public void Post_ContentIsNotNull(){
+        public void Post_EmailIsNotNull()
+        {
             //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silver@test.com";
+            const string Content = "This is some content";
+            const string userEmail = "damion.silver@test.com";
             //act
             Post newcomment = new Post(userEmail, Content);
 
             //assert
-                Assert.NotNull(newcomment.Content);
+            Assert.NotNull(newcomment.UserEmail);
         }
 
-            [Fact]
-        public void Post_EmailisFormattedCorrectly(){
+
+        [Fact]
+        public void Post_EmailEquality()
+        {
+
             //arrange
-                const string Content = "This is some content";
-                const string userEmail = "damion.silver@test.com";
+            const string Content = "This is some content";
+            const string userEmail = "damion.silver@test.com";
             //act
             Post newcomment = new Post(userEmail, Content);
 
             //assert
-                Assert.Contains("@", newcomment.UserEmail);
-        }
-
-           public void Post_EmailFormationThrowsException(){
-          
-                const string Content = "This is some content";
-                const string userEmail = "damion.silvertest.com";
-        
-                Assert.Throws<ArgumentException>(() => new Post(userEmail, Content));
-
+            Assert.Equal(userEmail, newcomment.UserEmail);
         }
 
 
-        
+        [Fact]
+        public void Post_ContentIsNotNull()
+        {
+            //arrange
+            const string Content = "This is some content";
+            const string userEmail = "damion.silver@test.com";
+            //act
+            Post newcomment = new Post(userEmail, Content);
 
+            //assert
+            Assert.NotNull(newcomment.Content);
+        }
 
+        [Fact]
+        public void Post_EmailisFormattedCorrectly()
+        {
+            //arrange
+            const string Content = "This is some content";
+            const string userEmail = "damion.silver@test.com";
+            //act
+            Post newcomment = new Post(userEmail, Content);
 
+            //assert
+            Assert.Contains("@", newcomment.UserEmail);
+        }
 
+        public void Post_EmailFormationThrowsException()
+        {
 
+            const string Content = "This is some content";
+            const string userEmail = "damion.silvertest.com";
 
+            Assert.Throws<ArgumentException>(() => new Post(userEmail, Content));
 
-
-
-
-
-
-
-
-
-
-
+        }
     }
 }

--- a/Fakebook.Posts/Fakebook.Posts.UnitTests/PostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.UnitTests/PostTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Fakebook.Posts.Domain.Models;
+using Xunit;
+namespace Fakebook.Posts.UnitTests
+{
+
+    public class PostTests{
+        private const int Id = 1;
+        [Fact]
+        public void Post_Constructor_Pass(){
+            //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silver@test.com";
+            //act
+            Post newpost = new Post(userEmail,Content);
+
+            //assert
+                Assert.NotNull(newpost);
+        }
+    
+
+         [Fact]
+        public void Post_EmailIsNotNull(){
+            //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silver@test.com";
+            //act
+            Post newcomment = new Post(userEmail, Content);
+
+            //assert
+                Assert.NotNull(newcomment.UserEmail);
+        }
+
+
+        [Fact]
+        public void Post_EmailEquality(){
+
+             //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silver@test.com";
+            //act
+            Post newcomment = new Post(userEmail, Content);
+
+            //assert
+                Assert.Equal(userEmail,newcomment.UserEmail);
+        }
+
+
+            [Fact]
+        public void Post_ContentIsNotNull(){
+            //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silver@test.com";
+            //act
+            Post newcomment = new Post(userEmail, Content);
+
+            //assert
+                Assert.NotNull(newcomment.Content);
+        }
+
+            [Fact]
+        public void Post_EmailisFormattedCorrectly(){
+            //arrange
+                const string Content = "This is some content";
+                const string userEmail = "damion.silver@test.com";
+            //act
+            Post newcomment = new Post(userEmail, Content);
+
+            //assert
+                Assert.Contains("@", newcomment.UserEmail);
+        }
+
+           public void Post_EmailFormationThrowsException(){
+          
+                const string Content = "This is some content";
+                const string userEmail = "damion.silvertest.com";
+        
+                Assert.Throws<ArgumentException>(() => new Post(userEmail, Content));
+
+        }
+
+
+        
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    }
+}

--- a/Fakebook.Posts/Fakebook.Posts.sln
+++ b/Fakebook.Posts/Fakebook.Posts.sln
@@ -3,13 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30804.86
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fakebook.Posts.RestApi", "Fakebook.Posts.RestApi\Fakebook.Posts.RestApi.csproj", "{47D50303-3EF3-4F30-814C-D69740CB88CB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fakebook.Posts.RestApi", "Fakebook.Posts.RestApi\Fakebook.Posts.RestApi.csproj", "{47D50303-3EF3-4F30-814C-D69740CB88CB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fakebook.Posts.Domain", "Fakebook.Posts.Domain\Fakebook.Posts.Domain.csproj", "{F34FB2D4-21D6-48CF-BED1-0FEB7B694E11}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fakebook.Posts.Domain", "Fakebook.Posts.Domain\Fakebook.Posts.Domain.csproj", "{F34FB2D4-21D6-48CF-BED1-0FEB7B694E11}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fakebook.Posts.DataAccess", "Fakebook.Posts.DataAccess\Fakebook.Posts.DataAccess.csproj", "{D8DB7EEF-4E2B-4EA5-A5DB-0B0EA582BC9D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fakebook.Posts.DataAccess", "Fakebook.Posts.DataAccess\Fakebook.Posts.DataAccess.csproj", "{D8DB7EEF-4E2B-4EA5-A5DB-0B0EA582BC9D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fakebook.Posts.UnitTests", "Fakebook.Posts.UnitTests\Fakebook.Posts.UnitTests.csproj", "{F787297F-985C-496C-8894-46867C676171}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fakebook.Posts.UnitTests", "Fakebook.Posts.UnitTests\Fakebook.Posts.UnitTests.csproj", "{F787297F-985C-496C-8894-46867C676171}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fakebook.Posts.IntegrationTests", "Fakebook.Posts.IntegrationTests\Fakebook.Posts.IntegrationTests.csproj", "{5CAB5BBC-C96C-4DAD-9EA8-80909B1A4654}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{F787297F-985C-496C-8894-46867C676171}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F787297F-985C-496C-8894-46867C676171}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F787297F-985C-496C-8894-46867C676171}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CAB5BBC-C96C-4DAD-9EA8-80909B1A4654}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CAB5BBC-C96C-4DAD-9EA8-80909B1A4654}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CAB5BBC-C96C-4DAD-9EA8-80909B1A4654}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CAB5BBC-C96C-4DAD-9EA8-80909B1A4654}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Fakebook.Posts/app.dockerfile
+++ b/Fakebook.Posts/app.dockerfile
@@ -9,6 +9,7 @@ COPY Fakebook.Posts.Domain/*.csproj Fakebook.Posts.Domain/
 COPY Fakebook.Posts.DataAccess/*.csproj Fakebook.Posts.DataAccess/
 COPY Fakebook.Posts.RestApi/*.csproj Fakebook.Posts.RestApi/
 COPY Fakebook.Posts.UnitTests/*.csproj Fakebook.Posts.UnitTests/
+COPY Fakebook.Posts.IntegrationTests/*.csproj Fakebook.Posts.IntegrationTests/
 COPY *.sln ./
 RUN dotnet restore
 # ---------------------------------

--- a/Fakebook.Posts/db.dockerfile
+++ b/Fakebook.Posts/db.dockerfile
@@ -7,6 +7,7 @@ COPY Fakebook.Posts.Domain/*.csproj Fakebook.Posts.Domain/
 COPY Fakebook.Posts.DataAccess/*.csproj Fakebook.Posts.DataAccess/
 COPY Fakebook.Posts.RestApi/*.csproj Fakebook.Posts.RestApi/
 COPY Fakebook.Posts.UnitTests/*.csproj Fakebook.Posts.UnitTests/
+COPY Fakebook.Posts.IntegrationTests/*.csproj Fakebook.Posts.IntegrationTests/
 COPY *.sln ./
 RUN dotnet restore
 # ---------------------------------


### PR DESCRIPTION
Originally, unit testing was mistaken for integration testing. We switched the directories, and we realized we had no unit testing for the business logic. We implemented Unit testing for the comment and post models inside the unit testing directory.