### PR TITLE
Changed DateTime.Now in tests to a constant time to make tests more reproducible

### DIFF
--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/DeleteCommentTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/DeleteCommentTests.cs
@@ -15,7 +15,6 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
 {
     public class DeleteCommentTests : IClassFixture<WebApplicationFactory<Startup>>
     {
-
         private readonly WebApplicationFactory<Startup> _factory;
 
         public DeleteCommentTests(WebApplicationFactory<Startup> factory)
@@ -29,14 +28,13 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
         [Fact]
         public async Task DeleteAsync_ValidId_Deletes()
         {
-
             // Arrange
             Mock<IPostsRepository> mockRepo = new();
 
             mockRepo.Setup(r => r.DeleteCommentAsync(It.IsAny<int>()))
                 .Returns(new ValueTask());
 
-            var date = DateTime.Now;
+            var date = new DateTime(2021, 4, 4);
             Post post = new("test.user@email.com", "test content")
             {
                 Id = 1,
@@ -83,14 +81,13 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
         [Fact]
         public async Task DeleteAsync_InvalidId_NotFound()
         {
-
             // Arrange
             Mock<IPostsRepository> mockRepo = new();
 
             mockRepo.Setup(r => r.DeleteCommentAsync(It.IsAny<int>()))
                 .Throws(new ArgumentException());
 
-            var date = DateTime.Now;
+            var date = new DateTime(2021, 4, 4);
             Post post = new("test.user@email.com", "test content")
             {
                 Id = 1,

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/EditPostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/EditPostTests.cs
@@ -19,7 +19,6 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
 {
     public class EditPostTests : IClassFixture<WebApplicationFactory<Startup>>
     {
-
         private readonly WebApplicationFactory<Startup> _factory;
 
         public EditPostTests(WebApplicationFactory<Startup> factory)
@@ -67,7 +66,7 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
                 Id = 1,
                 Comments = new HashSet<Comment>(),
                 Picture = "picture",
-                CreatedAt = DateTime.Now
+                CreatedAt = new DateTime(2021, 4, 4)
             };
 
             StringContent stringContent = new(System.Text.Json.JsonSerializer.Serialize(post), Encoding.UTF8, "application/json");
@@ -120,7 +119,7 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
                 Id = 1,
                 Comments = new HashSet<Comment>(),
                 Picture = "picture",
-                CreatedAt = DateTime.Now
+                CreatedAt = new DateTime(2021, 4, 4)
             };
 
             StringContent stringContent = new(System.Text.Json.JsonSerializer.Serialize(post), Encoding.UTF8, "application/json");

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/PostCreation.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/PostCreation.cs
@@ -19,7 +19,6 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
 {
     public class PostControllerTest : IClassFixture<WebApplicationFactory<Startup>>
     {
-
         private readonly WebApplicationFactory<Startup> _factory;
 
         public PostControllerTest(WebApplicationFactory<Startup> factory)
@@ -33,13 +32,12 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
         [Fact]
         public async Task PostAsync_ValidPost_Creates()
         {
-
             // Arrange
             Mock<IPostsRepository> mockRepo = new();
             Mock<IFollowsRepository> mockFollowRepo = new();
             Mock<IBlobService> mockBlobService = new();
             List<Comment> comments = new();
-            var date = DateTime.Now;
+            var date = new DateTime(2021, 4, 4);
             Post post = new("test.user@email.com", "test content")
             {
                 Id = 1,
@@ -89,7 +87,7 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
                 .Throws(new DbUpdateException());
 
             List<Comment> comments = new();
-            var date = DateTime.Now;
+            var date = new DateTime(2021, 4, 4);
             Post post = new("test.user@email.com", "test content")
             {
                 Id = 1,
@@ -129,7 +127,7 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
         {
             // Arrange
             Mock<IPostsRepository> mockRepo = new();
-            var date = DateTime.Now;
+            var date = new DateTime(2021, 4, 4);
             Post post = new("test.user@email.com", "test content")
             {
                 Id = 1,
@@ -167,8 +165,8 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
             // Assert
             response.EnsureSuccessStatusCode();
             Assert.Equal(System.Net.HttpStatusCode.Created, response.StatusCode);
-
         }
+
         /// <summary>
         /// Tests the PostsController class' PostAsync method. Ensures that an improper Post object results in Status400BadRequest with an error message in the body.
         /// </summary>
@@ -177,7 +175,7 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
         {
             // Arrange
             Mock<IPostsRepository> mockRepo = new();
-            var date = DateTime.Now;
+            var date = new DateTime(2021, 4, 4);
             Post post = new("test.user@email.com", "test content")
             {
                 Id = 1,


### PR DESCRIPTION
Previously all of the integration tests were using DateTime.Now. Unfortunately, this makes tests impossible to reproduce if they somehow failed. I now changed the DateTime.Now to a constant time/date (April 4, 2021) in the tests to allow for the tests to be reproducible; the results of the tests should no longer depend on when the test was ran.