### PR TITLE
Fixed bug "Queryable doesn't implement IAsyncQueryProvider" for PostController.GetAsync

### DIFF
--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/FakebookPostsContext.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/FakebookPostsContext.cs
@@ -121,7 +121,7 @@ namespace Fakebook.Posts.DataAccess
                         Id = 1,
                         UserEmail = "testaccount@gmail.com",
                         Content = "Nice",
-                        CreatedAt = new DateTimeOffset(new DateTime(2021, 3, 3, 3, 2, 2)),
+                        CreatedAt = = new DateTimeOffset(new DateTime(2021, 3, 3, 3, 2, 2)),
                         PostId = 1
                     }
                 });

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/FakebookPostsContext.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/FakebookPostsContext.cs
@@ -1,14 +1,13 @@
-﻿using Fakebook.Posts.DataAccess.Models;
+﻿using System;
+using Fakebook.Posts.DataAccess.Models;
 using Microsoft.EntityFrameworkCore;
-using System;
 
 namespace Fakebook.Posts.DataAccess
 {
     public class FakebookPostsContext : DbContext
     {
-        public FakebookPostsContext(DbContextOptions<FakebookPostsContext> options) : base(options)
-        {
-        }
+
+        public FakebookPostsContext(DbContextOptions<FakebookPostsContext> options) : base(options) { }
 
         public virtual DbSet<Post> Posts { get; set; }
         public virtual DbSet<Comment> Comments { get; set; }
@@ -104,14 +103,14 @@ namespace Fakebook.Posts.DataAccess
                         Id = 1,
                         UserEmail = "john.werner@revature.net",
                         Content = "Just made my first post!",
-                        CreatedAt = new DateTimeOffset(new DateTime(2021, 2, 2, 2, 2, 2))
+                        CreatedAt = DateTimeOffset.Now
                     },
                     new Post
                     {
                         Id = 2,
                         UserEmail = "testaccount@gmail.com",
                         Content = "Fakebook is really cool.",
-                        CreatedAt = new DateTimeOffset(new DateTime(2021, 3, 3, 3, 3, 3))
+                        CreatedAt = DateTimeOffset.Now
                     }
                 });
 
@@ -121,7 +120,7 @@ namespace Fakebook.Posts.DataAccess
                         Id = 1,
                         UserEmail = "testaccount@gmail.com",
                         Content = "Nice",
-                        CreatedAt = = new DateTimeOffset(new DateTime(2021, 3, 3, 3, 2, 2)),
+                        CreatedAt = DateTimeOffset.Now,
                         PostId = 1
                     }
                 });

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/FakebookPostsContext.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/FakebookPostsContext.cs
@@ -121,7 +121,7 @@ namespace Fakebook.Posts.DataAccess
                         Id = 1,
                         UserEmail = "testaccount@gmail.com",
                         Content = "Nice",
-                        CreatedAt = = new DateTimeOffset(new DateTime(2021, 3, 3, 3, 2, 2)),
+                        CreatedAt = new DateTimeOffset(new DateTime(2021, 3, 3, 3, 2, 2)),
                         PostId = 1
                     }
                 });

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/FakebookPostsContext.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/FakebookPostsContext.cs
@@ -1,13 +1,14 @@
-﻿using System;
-using Fakebook.Posts.DataAccess.Models;
+﻿using Fakebook.Posts.DataAccess.Models;
 using Microsoft.EntityFrameworkCore;
+using System;
 
 namespace Fakebook.Posts.DataAccess
 {
     public class FakebookPostsContext : DbContext
     {
-
-        public FakebookPostsContext(DbContextOptions<FakebookPostsContext> options) : base(options) { }
+        public FakebookPostsContext(DbContextOptions<FakebookPostsContext> options) : base(options)
+        {
+        }
 
         public virtual DbSet<Post> Posts { get; set; }
         public virtual DbSet<Comment> Comments { get; set; }
@@ -103,14 +104,14 @@ namespace Fakebook.Posts.DataAccess
                         Id = 1,
                         UserEmail = "john.werner@revature.net",
                         Content = "Just made my first post!",
-                        CreatedAt = DateTimeOffset.Now
+                        CreatedAt = new DateTimeOffset(new DateTime(2021, 2, 2, 2, 2, 2))
                     },
                     new Post
                     {
                         Id = 2,
                         UserEmail = "testaccount@gmail.com",
                         Content = "Fakebook is really cool.",
-                        CreatedAt = DateTimeOffset.Now
+                        CreatedAt = new DateTimeOffset(new DateTime(2021, 3, 3, 3, 3, 3))
                     }
                 });
 
@@ -120,7 +121,7 @@ namespace Fakebook.Posts.DataAccess
                         Id = 1,
                         UserEmail = "testaccount@gmail.com",
                         Content = "Nice",
-                        CreatedAt = DateTimeOffset.Now,
+                        CreatedAt = = new DateTimeOffset(new DateTime(2021, 3, 3, 3, 2, 2)),
                         PostId = 1
                     }
                 });

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
@@ -57,7 +57,7 @@ namespace Fakebook.Posts.DataAccess.Repositories
 
         public async ValueTask<Post> GetAsync(int postId)
         {
-            var post = await _context.Posts.FirstOrDefaultAsync(p => p.Id == postId);
+            var post = await _context.Posts.FirstAsync(p => p.Id == postId);
             return post.ToDomain();
         }
 

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
@@ -57,7 +57,8 @@ namespace Fakebook.Posts.DataAccess.Repositories
 
         public async ValueTask<Post> GetAsync(int postId)
         {
-            return null;
+            var post = await _context.Posts.FirstOrDefaultAsync(p => p.Id == postId);
+            return post.ToDomain();
         }
 
         public async ValueTask<Comment> AddCommentAsync(Comment comment)

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
@@ -1,13 +1,13 @@
+using Fakebook.Posts.DataAccess.Mappers;
+using Fakebook.Posts.Domain.Interfaces;
+using Fakebook.Posts.Domain.Models;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Fakebook.Posts.DataAccess.Mappers;
-using Fakebook.Posts.Domain.Interfaces;
-using Fakebook.Posts.Domain.Models;
-using Microsoft.EntityFrameworkCore;
 
 namespace Fakebook.Posts.DataAccess.Repositories
 {
@@ -27,6 +27,7 @@ namespace Fakebook.Posts.DataAccess.Repositories
             ).ToListAsync();
             return posts.Select(p => p.ToDomain());
         }
+
         /*
         SELECT *
         FROM (
@@ -52,6 +53,11 @@ namespace Fakebook.Posts.DataAccess.Repositories
             await _context.Posts.AddAsync(postDb);
             await _context.SaveChangesAsync();
             return postDb.ToDomain();
+        }
+
+        public async ValueTask<Post> GetAsync(int postId)
+        {
+            return null;
         }
 
         public async ValueTask<Comment> AddCommentAsync(Comment comment)

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Interfaces/IPostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Interfaces/IPostsRepository.cs
@@ -1,20 +1,31 @@
-﻿using System.Collections.Generic;
+﻿using Fakebook.Posts.Domain.Models;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Fakebook.Posts.Domain.Models;
 
 namespace Fakebook.Posts.Domain.Interfaces
 {
     public interface IPostsRepository : IEnumerable<Post>, IAsyncEnumerable<Post>
     {
         ValueTask<Post> AddAsync(Post post);
+
+        ValueTask<Post> GetAsync(int postId);
+
         ValueTask<Comment> AddCommentAsync(Comment comment);
+
         ValueTask UpdateAsync(Post post);
+
         ValueTask DeletePostAsync(int id);
+
         ValueTask DeleteCommentAsync(int id);
+
         Task<bool> LikePostAsync(int postId, string userEmail);
+
         Task<bool> UnlikePostAsync(int postId, string userEmail);
+
         Task<bool> LikeCommentAsync(int commentId, string userEmail);
+
         Task<bool> UnlikeCommentAsync(int commentId, string userEmail);
+
         Task<IEnumerable<Post>> NewsfeedAsync(string email, int count);
     }
 }

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/GetPostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/GetPostTests.cs
@@ -70,7 +70,7 @@ namespace Fakebook.Posts.IntegrationTests.ClientActions
             Mock<IFollowsRepository> mockFollowRepo = new();
             Mock<IBlobService> mockBlobService = new();
             mockRepo.Setup(r => r.GetAsync(It.IsAny<int>()))
-                .ReturnsAsync(null as Post);
+                .Throws(new InvalidOperationException());
 
             var client = _factory.WithWebHostBuilder(builder =>
             {

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/GetPostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/GetPostTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -34,7 +35,7 @@ namespace Fakebook.Posts.IntegrationTests.ClientActions
             Mock<IBlobService> mockBlobService = new();
             Post post = new Post("test.user@email.com", "test content") { Id = 1 };
             mockRepo.Setup(r => r.GetAsync(It.IsAny<int>()))
-                .Returns(ValueTask.FromResult(post));
+                .ReturnsAsync(post);
 
             var client = _factory.WithWebHostBuilder(builder =>
             {
@@ -51,7 +52,7 @@ namespace Fakebook.Posts.IntegrationTests.ClientActions
             client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Test");
 
             // Act
-            var response = await client.GetAsync("api/posts/1");
+            var response = await client.GetAsync(new Uri("api/posts/1", UriKind.Relative));
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -69,7 +70,7 @@ namespace Fakebook.Posts.IntegrationTests.ClientActions
             Mock<IFollowsRepository> mockFollowRepo = new();
             Mock<IBlobService> mockBlobService = new();
             mockRepo.Setup(r => r.GetAsync(It.IsAny<int>()))
-                .Returns(ValueTask.FromResult<Post>(null));
+                .ReturnsAsync(null as Post);
 
             var client = _factory.WithWebHostBuilder(builder =>
             {
@@ -86,7 +87,7 @@ namespace Fakebook.Posts.IntegrationTests.ClientActions
             client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Test");
 
             // Act
-            var response = await client.GetAsync("api/posts/1");
+            var response = await client.GetAsync(new Uri("api/posts/1", UriKind.Relative));
 
             // Assert
             Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/GetPostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/GetPostTests.cs
@@ -32,8 +32,9 @@ namespace Fakebook.Posts.IntegrationTests.ClientActions
             Mock<IPostsRepository> mockRepo = new();
             Mock<IFollowsRepository> mockFollowRepo = new();
             Mock<IBlobService> mockBlobService = new();
+            Post post = new Post("test.user@email.com", "test content") { Id = 1 };
             mockRepo.Setup(r => r.GetAsync(It.IsAny<int>()))
-                .Returns(ValueTask.FromResult(new Post("test.user@email.com", "test content") { Id = 1 }));
+                .Returns(ValueTask.FromResult(post));
 
             var client = _factory.WithWebHostBuilder(builder =>
             {

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/GetPostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/GetPostTests.cs
@@ -1,0 +1,69 @@
+﻿using Fakebook.Posts.Domain.Interfaces;
+using Fakebook.Posts.Domain.Models;
+using Fakebook.Posts.IntegrationTests.Services;
+using Fakebook.Posts.RestApi;
+using Fakebook.Posts.RestApi.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fakebook.Posts.IntegrationTests.ClientActions
+{
+    public class GetPostTests : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private readonly WebApplicationFactory<Startup> _factory;
+
+        public GetPostTests(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        /// <summary>
+        /// Tests the PostsController class' PutAsync method. Ensures that a proper Post object results in status 204NoContent.
+        /// </summary>
+        [Fact]
+        public async Task GetAsync_ValidId_ReturnsPost()
+        {
+            // Arrange
+            Mock<IPostsRepository> mockRepo = new();
+            Mock<IFollowsRepository> mockFollowRepo = new();
+            Mock<IBlobService> mockBlobService = new();
+            mockRepo.Setup(r => r.GetAsync(It.IsAny<int>()))
+                .Returns(new ValueTask<Post>());
+
+            HashSet<Post> posts = new()
+            {
+                new("test.user@email.com", "test content") { Id = 1 }
+            };
+
+            mockRepo.Setup(r => r.GetEnumerator())
+                .Returns(posts.GetEnumerator());
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddScoped(sp => mockRepo.Object);
+                    services.AddScoped(sp => mockFollowRepo.Object);
+                    services.AddTransient(sp => mockBlobService.Object);
+                    services.AddAuthentication("Test")
+                        .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", options => { });
+                });
+            }).CreateClient();
+
+            client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Test");
+
+            // Act
+            var response = await client.GetAsync("api/posts/1");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+}

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/GetPostTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/GetPostTests.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -34,15 +33,7 @@ namespace Fakebook.Posts.IntegrationTests.ClientActions
             Mock<IFollowsRepository> mockFollowRepo = new();
             Mock<IBlobService> mockBlobService = new();
             mockRepo.Setup(r => r.GetAsync(It.IsAny<int>()))
-                .Returns(new ValueTask<Post>());
-
-            HashSet<Post> posts = new()
-            {
-                new("test.user@email.com", "test content") { Id = 1 }
-            };
-
-            mockRepo.Setup(r => r.GetEnumerator())
-                .Returns(posts.GetEnumerator());
+                .Returns(ValueTask.FromResult(new Post("test.user@email.com", "test content") { Id = 1 }));
 
             var client = _factory.WithWebHostBuilder(builder =>
             {

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/PostRepository_CreateTest.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/PostRepository_CreateTest.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Linq;
-using Fakebook.Posts.DataAccess;
+﻿using Fakebook.Posts.DataAccess;
 using Fakebook.Posts.DataAccess.Repositories;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading.Tasks;
 using Xunit;
-
 
 namespace Fakebook.Posts.IntegrationTests.PostRepository.Test
 {
@@ -60,6 +59,7 @@ namespace Fakebook.Posts.IntegrationTests.PostRepository.Test
             Assert.True(result.UserEmail == comment.UserEmail);
             Assert.True(result.CreatedAt == comment.CreatedAt);
         }
+
         [Fact]
         public async void CreatePost()
         {
@@ -94,9 +94,10 @@ namespace Fakebook.Posts.IntegrationTests.PostRepository.Test
         }
 
         [Fact]
-        public void GetPost_GetId_EqualsSetValue()
+        public async Task GetPost_GetId_EqualsSetValue()
         {
             // Arrange
+            int postId = 3;
             using SqliteConnection connection = new("Data Source=:memory:");
             connection.Open();
 
@@ -106,7 +107,7 @@ namespace Fakebook.Posts.IntegrationTests.PostRepository.Test
 
             DataAccess.Models.Post insertedPost = new()
             {
-                Id = 3,
+                Id = postId,
                 UserEmail = "person@domain.net",
                 Content = "New Content",
                 CreatedAt = DateTime.Now
@@ -120,8 +121,7 @@ namespace Fakebook.Posts.IntegrationTests.PostRepository.Test
             PostsRepository repo = new(context);
 
             // Act
-            var result = repo.AsQueryable().FirstOrDefault(
-                p => p.Id == 3);
+            var result = await repo.GetAsync(postId);
 
             // Assert
             Assert.IsAssignableFrom<Domain.Models.Post>(result);

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/PostRepository_CreateTest.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/PostRepository_CreateTest.cs
@@ -11,7 +11,7 @@ namespace Fakebook.Posts.IntegrationTests.PostRepository.Test
     public class PostRepository_CreateTest
     {
         [Fact]
-        public async void CreateComment()
+        public async Task CreateComment()
         {
             //Arrange
             using SqliteConnection connection = new("Data Source=:memory:");
@@ -61,7 +61,7 @@ namespace Fakebook.Posts.IntegrationTests.PostRepository.Test
         }
 
         [Fact]
-        public async void CreatePost()
+        public async Task CreatePost()
         {
             //Arrange
             using SqliteConnection connection = new("Data Source=:memory:");

--- a/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/PostsController.cs
+++ b/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/PostsController.cs
@@ -232,11 +232,15 @@ namespace Fakebook.Posts.RestApi.Controllers
         [ActionName(nameof(GetAsync))]
         public async Task<IActionResult> GetAsync(int id)
         {
-            var post = await _postsRepository.GetAsync(id);
-            if (post is not null)
+            try
+            {
+                var post = await _postsRepository.GetAsync(id);
                 return Ok(post);
-            else
+            }
+            catch (InvalidOperationException)
+            {
                 return NotFound();
+            }
         }
 
         /// <summary>

--- a/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/PostsController.cs
+++ b/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/PostsController.cs
@@ -232,9 +232,11 @@ namespace Fakebook.Posts.RestApi.Controllers
         [ActionName(nameof(GetAsync))]
         public async Task<IActionResult> GetAsync(int id)
         {
-            if (await _postsRepository.AsQueryable()
-                .FirstOrDefaultAsync(p => p.Id == id) is Post post) return Ok(post);
-            return NotFound();
+            var post = await _postsRepository.GetAsync(id);
+            if (post is not null)
+                return Ok(post);
+            else
+                return NotFound();
         }
 
         /// <summary>

--- a/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/PostsController.cs
+++ b/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/PostsController.cs
@@ -233,10 +233,7 @@ namespace Fakebook.Posts.RestApi.Controllers
         public async Task<IActionResult> GetAsync(int id)
         {
             var post = await _postsRepository.GetAsync(id);
-            if (post is not null)
-                return Ok(post);
-            else
-                return NotFound();
+            return Ok(post);
         }
 
         /// <summary>

--- a/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/PostsController.cs
+++ b/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/PostsController.cs
@@ -233,7 +233,10 @@ namespace Fakebook.Posts.RestApi.Controllers
         public async Task<IActionResult> GetAsync(int id)
         {
             var post = await _postsRepository.GetAsync(id);
-            return Ok(post);
+            if (post is not null)
+                return Ok(post);
+            else
+                return NotFound();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed a bug where calling the PostController.GetAsync would result in the error "Queryable doesn't implement IAsyncQueryProvider," which resulted in a 500 HttpResponse and no data being sent back to the client. 