### PR TITLE
Moved Comment Likes Over to the Comments Controller.

### DIFF
--- a/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/CommentsController.cs
+++ b/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/CommentsController.cs
@@ -144,5 +144,45 @@ namespace Fakebook.Posts.RestApi.Controllers
             }
             return NotFound();
         }
+
+        /// <summary>
+        /// Likes a comment for a User given a comment ID.
+        /// </summary>
+        /// <param name="commentId">Comment ID of comment to be liked</param>
+        /// <returns>
+        /// An IActionResult containing either a:
+        /// <br/>200 OK on success
+        /// <br/>404 Not Found if Comment can't be found
+        /// </returns>
+        [Authorize]
+        [HttpPost("{commentId}/like")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> LikeCommentAsync(int commentId)
+        {
+            var email = User.FindFirst(ct => ct.Type.Contains("nameidentifier")).Value;
+            if (await _postsRepository.LikeCommentAsync(commentId, email)) return Ok();
+            return NotFound();
+        }
+
+        /// <summary>
+        /// Unlikes a comment for a User given a comment ID.
+        /// </summary>
+        /// <param name="commentId">Comment ID of comment to be unliked</param>
+        /// <returns>
+        /// An IActionResult containing either a:
+        /// <br/>200 OK on success
+        /// <br/>404 Not Found if Comment can't be found
+        /// </returns>
+        [Authorize]
+        [HttpPost("{commentId}/unlike")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UnlikeCommentAsync(int commentId)
+        {
+            var email = User.FindFirst(ct => ct.Type.Contains("nameidentifier")).Value;
+            if (await _postsRepository.UnlikeCommentAsync(commentId, email)) return Ok();
+            return NotFound();
+        }
     }
 }

--- a/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/PostsController.cs
+++ b/Fakebook.Posts/Fakebook.Posts.RestApi/Controllers/PostsController.cs
@@ -178,46 +178,6 @@ namespace Fakebook.Posts.RestApi.Controllers
         }
 
         /// <summary>
-        /// Likes a comment for a User given a comment ID.
-        /// </summary>
-        /// <param name="commentId">Comment ID of comment to be liked</param>
-        /// <returns>
-        /// An IActionResult containing either a:
-        /// <br/>200 OK on success
-        /// <br/>404 Not Found if Comment can't be found
-        /// </returns>
-        [Authorize]
-        [HttpPost("{id}/comments/{commentId}/like")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> LikeCommentAsync(int commentId)
-        {
-            var email = User.FindFirst(ct => ct.Type.Contains("nameidentifier")).Value;
-            if (await _postsRepository.LikeCommentAsync(commentId, email)) return Ok();
-            return NotFound();
-        }
-
-        /// <summary>
-        /// Unlikes a comment for a User given a comment ID.
-        /// </summary>
-        /// <param name="commentId">Comment ID of comment to be unliked</param>
-        /// <returns>
-        /// An IActionResult containing either a:
-        /// <br/>200 OK on success
-        /// <br/>404 Not Found if Comment can't be found
-        /// </returns>
-        [Authorize]
-        [HttpPost("{id}/comments/{commentId}/unlike")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> UnlikeCommentAsync(int commentId)
-        {
-            var email = User.FindFirst(ct => ct.Type.Contains("nameidentifier")).Value;
-            if (await _postsRepository.UnlikeCommentAsync(commentId, email)) return Ok();
-            return NotFound();
-        }
-
-        /// <summary>
         /// Gets a post by ID
         /// </summary>
         /// <param name="id">Id of Post</param>


### PR DESCRIPTION
Previously, liking a comment was on the PostController, even though it had nothing to do with posts. Now, liking/unliking a comment is on the CommentController. This changes the REST endpoint from /api/posts/{postId}/comments/{commentId}/like to /api/comments/{commentId}/like. The postId wasn't even use previously anyway.