### PR TITLE
fixing the comment model issue where the post was referenced twice.

### DIFF
--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/FakebookPostsContext.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/FakebookPostsContext.cs
@@ -54,13 +54,6 @@ namespace Fakebook.Posts.DataAccess
                       .HasColumnType("timestamp with time zone")
                       .HasDefaultValueSql("NOW()")
                       .ValueGeneratedOnAdd();
-
-                entity.HasOne(e => e.Post)
-                      .WithMany(e => e.Comments)
-                      .IsRequired()
-                      .HasForeignKey(e => e.PostId)
-                      .HasConstraintName("FK_Comment_Post")
-                      .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<Follow>(entity =>

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Mappers/DataMapper.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Mappers/DataMapper.cs
@@ -58,7 +58,7 @@ namespace Fakebook.Posts.DataAccess.Mappers
             dbPost.CreatedAt = post.CreatedAt;
             if (post.Comments is not null)
                 dbPost.Comments = post.Comments
-                    .Select(c => c.ToDataAccess(dbPost)).ToHashSet();
+                    .Select(c => c.ToDataAccess(dbPost.Id)).ToHashSet();
             if (post.Likes is not null)
                 dbPost.PostLikes = post.Likes.Select(c =>
                     new PostLike
@@ -70,14 +70,13 @@ namespace Fakebook.Posts.DataAccess.Mappers
             return dbPost;
 
         }
-        public static Comment ToDataAccess(this Domain.Models.Comment comment, Post post)
+        public static Comment ToDataAccess(this Domain.Models.Comment comment, int postId)
         {
             Comment dbComment = new()
             {
                 Id = comment.Id,
                 UserEmail = comment.UserEmail,
-                PostId = post.Id,
-                Post = post,
+                PostId = postId,
                 Content = comment.Content,
                 CreatedAt = comment.CreatedAt,
                 CommentLikes = comment.Likes.Select(l => new CommentLike { CommentId = comment.Id, LikerEmail = l }).ToHashSet()

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Migrations/20210416192734_FixCommentModelIssue.Designer.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Migrations/20210416192734_FixCommentModelIssue.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Fakebook.Posts.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Fakebook.Posts.DataAccess.Migrations
 {
     [DbContext(typeof(FakebookPostsContext))]
-    partial class FakebookPostsContextModelSnapshot : ModelSnapshot
+    [Migration("20210416192734_FixCommentModelIssue")]
+    partial class FixCommentModelIssue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Migrations/20210416192734_FixCommentModelIssue.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Migrations/20210416192734_FixCommentModelIssue.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Fakebook.Posts.DataAccess.Migrations
+{
+    public partial class FixCommentModelIssue : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Comment_Post",
+                schema: "Fakebook",
+                table: "Comment");
+
+            migrationBuilder.UpdateData(
+                schema: "Fakebook",
+                table: "Comment",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "CreatedAt",
+                value: new DateTimeOffset(new DateTime(2021, 4, 16, 15, 27, 34, 251, DateTimeKind.Unspecified).AddTicks(7877), new TimeSpan(0, -4, 0, 0, 0)));
+
+            migrationBuilder.UpdateData(
+                schema: "Fakebook",
+                table: "Post",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "CreatedAt",
+                value: new DateTimeOffset(new DateTime(2021, 4, 16, 15, 27, 34, 247, DateTimeKind.Unspecified).AddTicks(7124), new TimeSpan(0, -4, 0, 0, 0)));
+
+            migrationBuilder.UpdateData(
+                schema: "Fakebook",
+                table: "Post",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "CreatedAt",
+                value: new DateTimeOffset(new DateTime(2021, 4, 16, 15, 27, 34, 250, DateTimeKind.Unspecified).AddTicks(5678), new TimeSpan(0, -4, 0, 0, 0)));
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Comment_Post_PostId",
+                schema: "Fakebook",
+                table: "Comment",
+                column: "PostId",
+                principalSchema: "Fakebook",
+                principalTable: "Post",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Comment_Post_PostId",
+                schema: "Fakebook",
+                table: "Comment");
+
+            migrationBuilder.UpdateData(
+                schema: "Fakebook",
+                table: "Comment",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "CreatedAt",
+                value: new DateTimeOffset(new DateTime(2021, 3, 30, 14, 1, 47, 100, DateTimeKind.Unspecified).AddTicks(5441), new TimeSpan(0, -6, 0, 0, 0)));
+
+            migrationBuilder.UpdateData(
+                schema: "Fakebook",
+                table: "Post",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "CreatedAt",
+                value: new DateTimeOffset(new DateTime(2021, 3, 30, 14, 1, 47, 95, DateTimeKind.Unspecified).AddTicks(9302), new TimeSpan(0, -6, 0, 0, 0)));
+
+            migrationBuilder.UpdateData(
+                schema: "Fakebook",
+                table: "Post",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "CreatedAt",
+                value: new DateTimeOffset(new DateTime(2021, 3, 30, 14, 1, 47, 98, DateTimeKind.Unspecified).AddTicks(6979), new TimeSpan(0, -6, 0, 0, 0)));
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Comment_Post",
+                schema: "Fakebook",
+                table: "Comment",
+                column: "PostId",
+                principalSchema: "Fakebook",
+                principalTable: "Post",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Models/Comment.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Models/Comment.cs
@@ -8,7 +8,6 @@ namespace Fakebook.Posts.DataAccess.Models
         public int Id { get; set; }
         public string UserEmail { get; set; }
         public int PostId { get; set; }
-        public Post Post { get; set; }
         public string Content { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
         public virtual ICollection<CommentLike> CommentLikes { get; set; }

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
@@ -59,7 +59,7 @@ namespace Fakebook.Posts.DataAccess.Repositories
         {
             if (await _context.Posts.FirstOrDefaultAsync(p => p.Id == comment.Post.Id) is Models.Post post)
             {
-                var commentDb = comment.ToDataAccess(post);
+                var commentDb = comment.ToDataAccess(post.Id);
                 await _context.Comments.AddAsync(commentDb);
                 await _context.SaveChangesAsync();
                 return commentDb.ToDomain(null);

--- a/Fakebook.Posts/Fakebook.Posts.UnitTests/DataMapper.Test/DataMapperTest.cs
+++ b/Fakebook.Posts/Fakebook.Posts.UnitTests/DataMapper.Test/DataMapperTest.cs
@@ -56,7 +56,7 @@ namespace Fakebook.Posts.UnitTests.DataMapper_Testing
             DataAccess.Models.Comment dbComent = new()
             {
                 Content = "Comment Content",
-                Post = dbPost,
+                PostId = dbPost.Id,
                 CreatedAt = DateTime.Now,
                 UserEmail = "person2@domain.net",
             };
@@ -96,11 +96,10 @@ namespace Fakebook.Posts.UnitTests.DataMapper_Testing
             domainComment.Likes.Add("a@b.d");
 
             //Act
-            var dbComment = domainComment.ToDataAccess(dbPost);
+            var dbComment = domainComment.ToDataAccess(dbPost.Id);
 
             //Assert
             Assert.True(dbComment.Content == domainComment.Content);
-            Assert.Equal(dbPost, dbComment.Post);
             Assert.True(dbComment.CreatedAt == domainComment.CreatedAt);
             Assert.True(dbComment.UserEmail == domainComment.UserEmail);
             Assert.True(dbComment.CommentLikes.Count == 1);


### PR DESCRIPTION
Inside of the comment model in  data access, the post was referenced twice. It referenced the post, and the postid. This caused an issue while running the newsfeed due to an loop.