### PR TITLE
Comment Json Searlization fix for infinite recursive serialization loop

### DIFF
--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Mappers/DataMapper.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Mappers/DataMapper.cs
@@ -30,7 +30,7 @@ namespace Fakebook.Posts.DataAccess.Mappers
         {
             Domain.Models.Comment domainComment = new(comment.UserEmail, comment.Content);
             domainComment.Id = comment.Id;
-            domainComment.Post = post;
+            domainComment.PostId = post.Id;
             domainComment.CreatedAt = comment.CreatedAt.LocalDateTime;
             if (comment.CommentLikes is not null)
                 domainComment.Likes = comment.CommentLikes

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
@@ -59,10 +59,11 @@ namespace Fakebook.Posts.DataAccess.Repositories
         {
             if (await _context.Posts.FirstOrDefaultAsync(p => p.Id == comment.PostId) is Models.Post post)
             {
+                var domainPost = post.ToDomain();
                 var commentDb = comment.ToDataAccess(post);
                 await _context.Comments.AddAsync(commentDb);
                 await _context.SaveChangesAsync();
-                return commentDb.ToDomain(null);
+                return commentDb.ToDomain(domainPost);
             }
             else
             {

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
@@ -57,7 +57,7 @@ namespace Fakebook.Posts.DataAccess.Repositories
 
         public async ValueTask<Comment> AddCommentAsync(Comment comment)
         {
-            if (await _context.Posts.FirstOrDefaultAsync(p => p.Id == comment.Post.Id) is Models.Post post)
+            if (await _context.Posts.FirstOrDefaultAsync(p => p.Id == comment.PostId) is Models.Post post)
             {
                 var commentDb = comment.ToDataAccess(post);
                 await _context.Comments.AddAsync(commentDb);
@@ -66,7 +66,7 @@ namespace Fakebook.Posts.DataAccess.Repositories
             }
             else
             {
-                throw new ArgumentException($"Post { comment.Post.Id } not found.", nameof(comment));
+                throw new ArgumentException($"Post { comment.PostId } not found.", nameof(comment));
             }
         }
 

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Models/Comment.cs
@@ -8,7 +8,7 @@ namespace Fakebook.Posts.Domain.Models
     {
         public int Id { get; set; }
         public string Content { get; set; }
-        public Post Post { get; set; }
+        public int PostId { get; set; }
         public string UserEmail { get; private set; }
         public DateTime CreatedAt { get; set; }
         public ICollection<string> Likes { get; set; }

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/DeleteCommentTests.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/DeleteCommentTests.cs
@@ -46,7 +46,7 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
             Comment comment = new("test.user@email.com", "comment content")
             {
                 Id = 1,
-                Post = post,
+                PostId = post.Id,
                 Content = "picture",
                 CreatedAt = date,
             };
@@ -99,7 +99,7 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
             Comment comment = new("test.user@email.com", "comment content")
             {
                 Id = 1,
-                Post = post,
+                PostId = post.Id,
                 Content = "picture",
                 CreatedAt = date,
             };

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/PostCreation.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/ClientActions/PostCreation.cs
@@ -176,7 +176,7 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
             Comment comment = new("test.user@email.com", "comment content")
             {
                 Id = 1,
-                Post = post,
+                PostId = post.Id,
                 Content = "picture",
                 CreatedAt = date,
             };
@@ -226,7 +226,7 @@ namespace Fakebook.Posts.IntegrationTests.Controllers
             Comment comment = new("test.user@email.com", "comment content")
             {
                 Id = 1,
-                Post = post,
+                PostId = post.Id,
                 Content = "picture",
                 CreatedAt = date,
             };

--- a/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/PostRepository_CreateTest.cs
+++ b/Fakebook.Posts/Fakebook.Posts.IntegrationTests/PostRepository.Test/PostRepository_CreateTest.cs
@@ -38,7 +38,7 @@ namespace Fakebook.Posts.IntegrationTests.PostRepository.Test
             Domain.Models.Comment comment = new("person@domain.net", "content")
             {
                 Id = 2,
-                Post = domainModelPost,
+                PostId = domainModelPost.Id,
                 CreatedAt = DateTime.Now
             };
 

--- a/Fakebook.Posts/Fakebook.Posts.UnitTests/DataMapper.Test/DataMapperTest.cs
+++ b/Fakebook.Posts/Fakebook.Posts.UnitTests/DataMapper.Test/DataMapperTest.cs
@@ -18,7 +18,7 @@ namespace Fakebook.Posts.UnitTests.DataMapper_Testing
 
             Domain.Models.Comment domainComment = new("person1@domain.net", "Comment Content")
             {
-                Post = domainPost,
+                PostId = domainPost.Id,
                 CreatedAt = DateTime.Now
             };
 
@@ -128,7 +128,7 @@ namespace Fakebook.Posts.UnitTests.DataMapper_Testing
 
             //Assert
             Assert.True(dbComment.Content == domainComment.Content);
-            Assert.Equal(domainPost, domainComment.Post);
+            Assert.Equal(domainPost.Id, domainComment.PostId);
             Assert.True(dbComment.CreatedAt == domainComment.CreatedAt);
             Assert.True(dbComment.UserEmail == domainComment.UserEmail);
             Assert.True(domainComment.Likes.Count == 1);


### PR DESCRIPTION
Inside of the domain models, a post was referenced more than once. This caused a recursive loop and our newsfeed failed.