### PR TITLE
change Spam detection TimeOut to 5 seconds instead of 10 seconds.

### DIFF
--- a/Fakebook.Posts/Fakebook.Posts.RestApi/Services/CheckSpamService.cs
+++ b/Fakebook.Posts/Fakebook.Posts.RestApi/Services/CheckSpamService.cs
@@ -33,7 +33,7 @@ namespace Fakebook.Posts.RestApi.Services
 			// posts can't be the same content within 'recentInMin' minutes
 			int recentInMin = 5;
 			// can't make new posts within 'secondsTimeout' seconds of another
-			int secondsTimeOut = 10;
+			int secondsTimeOut = 5;
 			var dateNow = _timeService.CurrentTime;
 			string userEmail = userPost.UserEmail;
 			string userEmailContent = userPost.Content;


### PR DESCRIPTION
Spam Service Timeout is set to 10 seconds before a user can post again. Changed to 5 seconds.