### PR TITLE
Used include statements inside of the GetPost method for comments and likes, and deleted a duplicate method.

### DIFF
--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
@@ -52,12 +52,11 @@ namespace Fakebook.Posts.DataAccess.Repositories
         public async ValueTask<Post> GetAsync(int postId)
         {
             var post = (await _context.Posts
-                    // .Include(p => p.PostLikes)
-                    // .Include(p => p.Comments)
-                    // .ThenInclude(c => c.CommentLikes)
-                    // .AsSplitQuery()
-                    .FirstOrDefaultAsync(b => b.Id == postId)).ToDomain();
-                    return post;
+                         .Include(p => p.PostLikes)
+                         .Include(p => p.Comments)
+                         .ThenInclude(c => c.CommentLikes)       
+                         .FirstOrDefaultAsync(b => b.Id == postId)).ToDomain();
+            return post;
         }
 
         public async ValueTask<Comment> AddCommentAsync(Comment comment)

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
@@ -51,8 +51,13 @@ namespace Fakebook.Posts.DataAccess.Repositories
 
         public async ValueTask<Post> GetAsync(int postId)
         {
-            var post = await _context.Posts.FirstAsync(p => p.Id == postId);
-            return post.ToDomain();
+            var post = (await _context.Posts
+                    // .Include(p => p.PostLikes)
+                    // .Include(p => p.Comments)
+                    // .ThenInclude(c => c.CommentLikes)
+                    // .AsSplitQuery()
+                    .FirstOrDefaultAsync(b => b.Id == postId)).ToDomain();
+                    return post;
         }
 
         public async ValueTask<Comment> AddCommentAsync(Comment comment)
@@ -205,18 +210,6 @@ namespace Fakebook.Posts.DataAccess.Repositories
                 return true;
             }
             return false;
-        }
-
-        public async ValueTask<Post> GetPostAsync(int id)
-        {
-
-            var post = (await _context.Posts
-                    .Include(p => p.PostLikes)
-                    .Include(p => p.Comments)
-                    .ThenInclude(c => c.CommentLikes)
-                    .FirstOrDefaultAsync(b => b.Id == id)).ToDomain();
-
-            return post;
         }
     }
 }

--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Repositories/PostsRepository.cs
@@ -210,7 +210,11 @@ namespace Fakebook.Posts.DataAccess.Repositories
         public async ValueTask<Post> GetPostAsync(int id)
         {
 
-            var post = (await _context.Posts.FirstOrDefaultAsync(b => b.Id == id)).ToDomain();
+            var post = (await _context.Posts
+                    .Include(p => p.PostLikes)
+                    .Include(p => p.Comments)
+                    .ThenInclude(c => c.CommentLikes)
+                    .FirstOrDefaultAsync(b => b.Id == id)).ToDomain();
 
             return post;
         }

--- a/Fakebook.Posts/Fakebook.Posts.Domain/Interfaces/IPostsRepository.cs
+++ b/Fakebook.Posts/Fakebook.Posts.Domain/Interfaces/IPostsRepository.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Fakebook.Posts.Domain.Models;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,7 +9,6 @@ namespace Fakebook.Posts.Domain.Interfaces
     {
         ValueTask<Post> AddAsync(Post post);
         
-        ValueTask<Post> GetPostAsync(int id);
 
         ValueTask<Post> GetAsync(int postId);
 


### PR DESCRIPTION
Included include statements inside of GetPost method for comments, likes, and commentlikes. I also deleted a duplicate method inside of our post repository (getpostasync). It did the same thing as GetPost, and it was never used. 