### PR TITLE
Fix postgres syntax issue inside of migration file.

### DIFF
--- a/Fakebook.Posts/Fakebook.Posts.DataAccess/Migrations/20210419031017_ChangedNowtoCurrentTime.cs
+++ b/Fakebook.Posts/Fakebook.Posts.DataAccess/Migrations/20210419031017_ChangedNowtoCurrentTime.cs
@@ -13,7 +13,7 @@ namespace Fakebook.Posts.DataAccess.Migrations
                 table: "Post",
                 type: "timestamp with time zone",
                 nullable: false,
-                defaultValueSql: "CURRENT_TIMESTAMP()",
+                defaultValueSql: "CURRENT_TIMESTAMP",
                 oldClrType: typeof(DateTimeOffset),
                 oldType: "timestamp with time zone",
                 oldDefaultValueSql: "NOW()");
@@ -24,7 +24,7 @@ namespace Fakebook.Posts.DataAccess.Migrations
                 table: "Comment",
                 type: "timestamp with time zone",
                 nullable: false,
-                defaultValueSql: "CURRENT_TIMESTAMP()",
+                defaultValueSql: "CURRENT_TIMESTAMP",
                 oldClrType: typeof(DateTimeOffset),
                 oldType: "timestamp with time zone",
                 oldDefaultValueSql: "NOW()");
@@ -65,7 +65,7 @@ namespace Fakebook.Posts.DataAccess.Migrations
                 defaultValueSql: "NOW()",
                 oldClrType: typeof(DateTimeOffset),
                 oldType: "timestamp with time zone",
-                oldDefaultValueSql: "CURRENT_TIMESTAMP()");
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
 
             migrationBuilder.AlterColumn<DateTimeOffset>(
                 name: "CreatedAt",
@@ -76,7 +76,7 @@ namespace Fakebook.Posts.DataAccess.Migrations
                 defaultValueSql: "NOW()",
                 oldClrType: typeof(DateTimeOffset),
                 oldType: "timestamp with time zone",
-                oldDefaultValueSql: "CURRENT_TIMESTAMP()");
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
 
             migrationBuilder.UpdateData(
                 schema: "Fakebook",


### PR DESCRIPTION
Inside of the migration file, dotnet added () at the end of Current_Timestamp. Current_Timestamp is an expression , which doesn't have () at the end. In order to fix this issue, I went inside of the migration files , and manually removed the four occurrences which included () at the end.